### PR TITLE
Potential fix for code scanning alert no. 41: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiodns==3.5.0
+argon2-cffi==25.1.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.15
 aiosignal==1.4.0


### PR DESCRIPTION
Potential fix for [https://github.com/rtk-rnjn/MomCare-Backend/security/code-scanning/41](https://github.com/rtk-rnjn/MomCare-Backend/security/code-scanning/41)

To address this problem, all password storage and verification should migrate from SHA-256 to a secure, modern password hashing scheme. The most robust and recommended library for this in Python is `argon2-cffi` (argon2), which is explicitly designed for handling password hashing, automatically generates salts, and is memory and CPU intensive to resist brute-force attacks. In practice:

- Replace the existing `hash_password` and `verify_password` methods in `TerminalExecutor` with methods using Argon2.
- Switch from storing and expecting a SHA-256 hash of the password to storing and using an Argon2 hash.
- Update imports and instantiate Argon2's `PasswordHasher` in `hash_password` and `verify_password`.
- Wherever `TerminalExecutor.hash_password` is used (e.g., when generating and comparing the password for authentication), it should use the Argon2 hash string, not a SHA-256 hexdigest.
- Ensure `argon2-cffi` is installed as a new dependency.
- Document that the stored hash value must now be in Argon2 format (existing SHA256 password hashes will not work).
- All changes are within `src/utils/terminal_executor.py` and relate specifically to the static password hashing interface.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
